### PR TITLE
Fix RegEx bug in MethodProcessor

### DIFF
--- a/library/src/main/java/com/cube/storm/language/lib/processor/MethodProcessor.java
+++ b/library/src/main/java/com/cube/storm/language/lib/processor/MethodProcessor.java
@@ -46,8 +46,8 @@ public class MethodProcessor
 			}
 		}
 
-		string = string.replaceAll("\\{" + originalString + "(\\.[0-9a-zA-Z]+)\\}", mappedVariable);
-		string = string.replaceAll("\\{" + originalString + "\\}", originalString);
+		string = string.replaceAll("\\{" + Pattern.quote(originalString) + "(\\.[0-9a-zA-Z]+)\\}", mappedVariable);
+		string = string.replaceAll("\\{" + Pattern.quote(originalString) + "\\}", originalString);
 
 		return string;
 	}


### PR DESCRIPTION
**What?**
Replaced regex pattern construction `"\\{" + originalString + ...` with `"\\{" + Pattern.quote(originalString) + ...` in the two occurrences within `MethodProcessor.process()`

**Why?**
If `originalString` contained any RegEx special characters, it could cause unexpected behaviours, ranging from failing to recognise matches to outright crashing an app.
For instance, if `originalString` has the value:
- "text", then a match for "{text}" would be successful
- "text?", then the pattern would be `"\\{text?\\}`, and since the `?` character in regex qualifies the previous character and is not escaped here, this would fail to match "{text?}"
- "text?*", then the pattern would be `"\\{text?*\\}`, which causes a `java.util.regex.PatternSyntaxException: Dangling meta character '*'` due to both `?` and `*` representing quantity qualifiers for the previous character in RegEx

**Anything else?**
This method is used exclusively when translating a Storm localisation with one or more Mappings, and the `originalString` in question is the value supplied for this Mapping key-value pair.
This fix should allow for values containing RegEx special characters to be used in Mappings without causing formatting issues or crashes.